### PR TITLE
Pass existing environment vars to sub-process

### DIFF
--- a/cdk_chalice.py
+++ b/cdk_chalice.py
@@ -131,8 +131,12 @@ class Chalice(cdk.Construct):
     def _package_app_subprocess(self, sam_package_dir):
         chalice_exe = shutil.which('chalice')
         command = [chalice_exe, 'package', '--stage', self.stage_name, sam_package_dir]
+        # load existing environment variables in order to pass them to chalice package sub process
+        # (for example: SSH_KEY)
+        env = os.environ.copy()
+
         # Chalice requires AWS_DEFAULT_REGION to be set for 'package' sub-command.
-        env = {'AWS_DEFAULT_REGION': _AWS_DEFAULT_REGION}
+        env.setdefault('AWS_DEFAULT_REGION', _AWS_DEFAULT_REGION)
 
         print(f'Packaging Chalice app for {self.stage_name}')
         subprocess.run(command, cwd=self.source_dir, env=env)


### PR DESCRIPTION
Load existing environment variables in order to pass them to chalice package sub process (for example: SSH_KEY). 
Before the change we could not use sshagent  to pass credentials to a sub-process since all environment variables were overridden in cdk_chalice.Chalice._package_app_subprocess,
For example
We use in the Pipfile:
[dev-packages]
\<package-name\> = {editable = true,git = "ssh://git@github.com/\<repository-name\>/\<package-name\>.git"}

However "pipenv install --dev" in the Jenkins pipeline has been failing to load this package due to missing SSH key.